### PR TITLE
Feature/add api token command key support #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,23 @@ npm install -g @liara/cli
 ```
 
 That's it.
+
+## How Contribute and Develop Liara CLI
+
+``` bash
+# install dependencies
+$ npm i
+
+# remove @liara/cli globaly
+$ npm uninstall -g @liara/cli
+
+# start webpack watch for development
+$ npm run dev
+
+# in the other bash run
+$ npm link
+```
+
+> at the end, don't forget run `npm unlink ` and then `npm install -g @liara/cli`
+
+If you have any further questions, please don’t hesitate to contact us.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ $ npm i
 # remove @liara/cli globaly
 $ npm uninstall -g @liara/cli
 
+# run test suite
+$ npm run test
+
 # start webpack watch for development
 $ npm run dev
 
-# in the other bash run
+# after `npm run dev` in the other bash you can run
 $ npm link
 ```
 

--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
   "author": "Mhe Mrg <mhemrg120@gmail.com> (http://liara.ir/)",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
-    "babel-preset-backpack": "^0.4.3",
+    "@babel/core": "^7.4.3",
+    "babel-loader": "^8.0.5",
+    "babel-preset-backpack": "*",
     "chai": "^4.1.2",
     "mocha": "^4.0.1",
     "shebang-loader": "^0.0.1",
     "webpack": "^3.8.1",
+    "webpack-cli": "^3.3.0",
     "webpack-node-externals": "^1.6.0"
   },
   "dependencies": {

--- a/src/liara.js
+++ b/src/liara.js
@@ -33,7 +33,12 @@ const liaraConfPath = join(homedir(), '.liara.json');
 
 let liaraConf;
 try {
-  liaraConf = JSON.parse(readFileSync(liaraConfPath));
+  if(!args.api_token){
+    liaraConf = JSON.parse(readFileSync(liaraConfPath));   
+  }else{
+    liaraConf = {}
+    liaraConf["api_token"] = args.api_token;
+  }
 } catch(err) {
   liaraConf = {};
 }

--- a/src/liara.js
+++ b/src/liara.js
@@ -37,7 +37,7 @@ try {
     liaraConf = JSON.parse(readFileSync(liaraConfPath));   
   }else{
     liaraConf = {}
-    liaraConf["api_token"] = args.api_token;
+    liaraConf["api-token"] = args.api_token;
   }
 } catch(err) {
   liaraConf = {};


### PR DESCRIPTION
Hi, as I mentioned in issue #3, I found a way to make it easy deployment for CI/CD.
now we can use `cli` like below:

```bash
$ liara deploy --port <project-port> --project <project-name> --api_token <your-token>
```
If you have any further questions about the concept of implementations, I'll be glad to be accountable 😊